### PR TITLE
Fix db reply parsing

### DIFF
--- a/nimongo/errors.nim
+++ b/nimongo/errors.nim
@@ -7,3 +7,6 @@ type
 
     NotFound* = object of NimongoError
         ## Raises when querying of one documents returns empty result
+
+    ReplyFieldMissing* = object of NimongoError
+        ## Raises when reqired field in reply is missing

--- a/nimongo/mongotest.nim
+++ b/nimongo/mongotest.nim
@@ -59,7 +59,7 @@ suite "Mongo instance administration commands test suite":
     check("smanual" in sdb.listCollections())
 
     discard waitFor(adb.createCollection("amanual"))
-    check("smanual" in waitFor(adb.listCollections()))
+    check("amanual" in waitFor(adb.listCollections()))
 
   test "[ASYNC] [SYNC] Command: 'listCollections'":
     let sclist = sdb.listCollections()
@@ -90,6 +90,17 @@ suite "Mongo connection error-handling operations":
   test "[ASYNC] [SYNC] Command: 'getLastError'":
     check(sm.getLastError().ok)
     check(waitFor(am.getLastError()).ok)
+
+  test "[ASYNC] [SYNC] Write operations error handling":
+    discard sdb.createCollection("smanual")
+    let sReplyCreate = sdb.createCollection("smanual")
+    check(not sReplyCreate.ok)
+    check(sReplyCreate.err.contains("already exists"))
+
+    discard waitFor(adb.createCollection("amanual"))
+    let aReplyCreate = waitFor(adb.createCollection("amanual"))
+    check(not aReplyCreate.ok)
+    check(aReplyCreate.err.contains("already exists"))
 
 suite "Authentication":
 
@@ -262,6 +273,7 @@ suite "Mongo client operations test suite":
     check(waitFor(aco.insert(@[%*{"string": "value"}, %*{"string": "value"}])))
     check(waitFor(aco.remove(%*{"string": "value"})).ok)
     check(waitFor(aco.find(%*{"string": "value"}).all()).len() == 0)
+
 
 suite "Mongo aggregation commands":
 

--- a/nimongo/reply.nim
+++ b/nimongo/reply.nim
@@ -1,7 +1,72 @@
+import bson
+import errors
+
 type StatusReply* = object  ## Database Reply
     ok*: bool
     n*: int
     err*: string
+
+template parseReplyField(b: untyped, field: untyped, default: untyped, body: untyped): untyped =
+  ## Take field from BSON. If field is missing and required than generate
+  ## "ReplyFieldMissing" exception. If field is missing and not required
+  ## than apply provided default value. If field exists than apply provided
+  ## calculations body code.
+  let b = reply[field]
+  if b == nil:
+    if isRequired:
+      raise newException(ReplyFieldMissing, "Required field \"" & field & "\" missing in reply")
+    else:
+      result = default
+  else:
+    body
+
+proc parseReplyOk(reply: Bson, isRequired: bool): bool {.raises: [ReplyFieldMissing, Exception]} =
+  ## Parse "ok" field in database reply.
+  parseReplyField(val, "ok", false):
+    result = val == 1.0'f64
+
+proc parseReplyN(reply: Bson, isRequired: bool): int {.raises: [ReplyFieldMissing, Exception]} =
+  ## Parse "n" field in database reply.
+  parseReplyField(val, "n", 0):
+    case val.kind
+    of BsonKindDouble:
+      result = val.toFloat64.int
+    else:
+      result = val.toInt
+
+proc parseReplyErrmsg(reply: Bson, isRequired: bool): string {.raises: [ReplyFieldMissing, Exception]} =
+  ## Parse "errmsg" field in database reply.
+  parseReplyField(val, "errmsg", ""):
+    if val.kind == BsonKindStringUTF8:
+      result = val
+    else:
+      result = ""
+
+proc toStatusReply*(reply: Bson): StatusReply =
+  ## Create StatusReply object from database reply BSON document.
+  ## "ok" field is considered required. "n" and "errmsg" fields
+  ## are optional and they are parsed if exist in reply
+  result.ok = parseReplyOk(reply, true)
+  result.n = parseReplyN(reply, false)
+  result.err = parseReplyErrmsg(reply, false)
+
+proc isReplyOk*(reply: Bson): bool =
+  ## This function is useful if we would like to check only "ok" field
+  ## in reply and do not like to create full StatusReply object. Field
+  ## is considered required
+  result = parseReplyOk(reply, true)
+
+proc getReplyN*(reply: Bson): int =
+  ## This function is useful if we would like to check only "n" field
+  ## in reply and do not like to create full StatusReply object. Field
+  ## is considered required
+  result = parseReplyN(reply, true)
+
+proc getReplyErrmsg*(reply: Bson): string =
+  ## This function is useful if we would like to check only "errmsg" field
+  ## in reply and do not like to create full StatusReply object. Field
+  ## is considered required
+  result = parseReplyErrmsg(reply, true)
 
 converter toBool*(sr: StatusReply): bool = sr.ok
   ## If StatusReply.ok field is true = then StatusReply is considered


### PR DESCRIPTION
Main reason to do this PR is that [`insert`](https://github.com/SSPkrolik/nimongo/blob/e2f9df939931c40686ac83f5275ad950374ba6fe/nimongo/mongo.nim#L620) proc always failed on [`response["n"]`](https://github.com/SSPkrolik/nimongo/blob/e2f9df939931c40686ac83f5275ad950374ba6fe/nimongo/mongo.nim#L633) conversion. This is because value of `response["n"]` is `BsonKindDouble`. `nimongotest.nim` failed too.

To fix it I have unified database reply parsing. This should fix several issues like in `insert` but not break backwards compatibility. This also adds `errmsg` to `ReplyStatus` if error occurs in all cases.

Tested with
```
nim --version
Nim Compiler Version 0.15.1 (2016-10-15) [Linux: amd64]
git hash: 2d2b1a9d481bffaecac35e1e52929cea66f69e0e
```

```
mongod --version
db version v3.3.15
git version: 520f5571d039b57cf9c319b49654909828971073
```

`nimongotest.nim` green (fixed and updated it).