### PR TITLE
Inserted _id list tracked in StatusReply

### DIFF
--- a/nimongo/reply.nim
+++ b/nimongo/reply.nim
@@ -5,6 +5,7 @@ type StatusReply* = object  ## Database Reply
     ok*: bool
     n*: int
     err*: string
+    inserted_ids*: seq[Bson]
     bson*: Bson
 
 template parseReplyField(b: untyped, field: untyped, default: untyped, body: untyped): untyped =
@@ -47,14 +48,16 @@ proc parseReplyErrmsg(reply: Bson, isRequired: bool): string {.raises: [ReplyFie
     else:
       result = ""
 
-proc toStatusReply*(reply: Bson): StatusReply =
-  ## Create StatusReply object from database reply BSON document.
+proc toStatusReply*(reply: Bson, inserted_ids: seq[Bson] = @[]): StatusReply =
+  ## Create StatusReply object from database reply BSON document and
+  ## an optional list of OIDs.
   ## "ok" field is considered required. "n" and "errmsg" fields
   ## are optional and they are parsed if exist in reply
   result.bson = reply
   result.ok = parseReplyOk(reply, true)
   result.n = parseReplyN(reply, false)
   result.err = parseReplyErrmsg(reply, false)
+  result.inserted_ids = inserted_ids
 
 proc isReplyOk*(reply: Bson): bool =
   ## This function is useful if we would like to check only "ok" field


### PR DESCRIPTION
This update adds any missing `_id` from inserted documents and stores those in a `seq[Bson]` in StatusReply so that end user can identify the newly inserted documents. This is akin to what the Mongo Shell and related libraries typically do:

* https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/#insertmany-examples

* http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert_many

ref: issue #45 