### PR TITLE
Implement locking in more idiomatic nim style by checking for the threads:on flag at compile time

### DIFF
--- a/nimongo.nimble
+++ b/nimongo.nimble
@@ -12,13 +12,21 @@ proc runTest(input: string) =
   echo "running: " & cmd
   exec cmd
 
+proc runTestThreaded(input: string) =
+  let cmd = "nim c --threads:on -r " & input
+  echo "running: " & cmd
+  exec cmd
+
 proc testNoMongod() =
   runTest "nimongo/bson.nim"
   runTest "tests/bsontest.nim"
+  runTestThreaded "nimongo/bson.nim"
+  runTestThreaded "tests/bsontest.nim"
 
 task test, "tests":
   testNoMongod()
   runTest "tests/nimongotest.nim"
+  runTestThreaded "tests/nimongotest.nim"
 
 task test_ci, "tests for CI":
   testNoMongod()


### PR DESCRIPTION
See here for more details: https://github.com/nim-lang/Nim/issues/12330

TLDR;
Checking the `threads:on` flag is more idiomatic than forcing the include of `-pthreads` on Linux.

By making use of the `threads:on` flag, the proper thread libraries (and associated lock implementation), will be included for all supported nim platforms automatically.

I have also modified the test suite to test with both `threads:on` and no threads.

/cc @timotheecour 
This change passes the included test suite for me locally, but I don't use mongodb myself. Can you test this PR on your code to make it sure it works for a real world application?
Feel free to make any code review or other suggestions as well. 😄 
